### PR TITLE
CSSJSON function is exported in module.exports

### DIFF
--- a/cssjson.js
+++ b/cssjson.js
@@ -296,5 +296,6 @@ var CSSJSON = new function () {
 
 };
 
-if (typeof module == 'object')
+if (typeof module === 'object') {
     module.exports = CSSJSON;
+}

--- a/cssjson.js
+++ b/cssjson.js
@@ -295,3 +295,6 @@ var CSSJSON = new function () {
     };
 
 };
+
+if (typeof module == 'object')
+    module.exports = CSSJSON;


### PR DESCRIPTION
The existence of the `module` object is checked before doing the assignment. This would to simplify the use of the module with `require`.

Thanks
